### PR TITLE
Fix tagging - remove common tags merge as causing terraform plan to fail

### DIFF
--- a/ecr.tf
+++ b/ecr.tf
@@ -1,9 +1,8 @@
 resource "aws_ecr_repository" "kafka_reconciliation" {
   name = "kafka-reconciliation"
-  tags = merge(
-    local.common_tags,
-    { DockerHub : "dwpdigital/kafka-reconciliation" }
-  )
+  tags = {
+    DockerHub : "dwpdigital/kafka-reconciliation"
+  }
 }
 
 resource "aws_ecr_repository_policy" "kafka-reconciliation" {


### PR DESCRIPTION
Signed-off-by: Connor Avery <ConnorAvery@digital.uc.dwp.gov.uk>