### PR TITLE
Allow lambda to get table for glue job start operation

### DIFF
--- a/lambda_glue_launcher.tf
+++ b/lambda_glue_launcher.tf
@@ -83,6 +83,8 @@ data "aws_iam_policy_document" "glue_launcher_lambda" {
     effect = "Allow"
     actions = [
       "glue:StartJobRun",
+      "glue:GetTable",
+      "glue:GetDatabase",
     ]
     resources = [
       "*"


### PR DESCRIPTION
Signed-off-by: Connor Avery <ConnorAvery@digital.uc.dwp.gov.uk>