### PR TITLE
Starting state can be skipped so use running instead

### DIFF
--- a/cloudwatch_events.tf
+++ b/cloudwatch_events.tf
@@ -11,7 +11,7 @@ resource "aws_cloudwatch_event_rule" "kafka_reconciliation_started" {
   ],
   "detail": {
     "state": [
-      "STARTING"
+      "RUNNING"
     ],
     "jobName": [
       "${data.terraform_remote_state.dataworks-aws-ingest-consumers.outputs.manifest_etl.job_name_combined}"


### PR DESCRIPTION
Starting state can be skipped so use running instead